### PR TITLE
Update help tab

### DIFF
--- a/inst/md/help/batch.md
+++ b/inst/md/help/batch.md
@@ -14,10 +14,11 @@
 ### Locked parameter set
 
 `Locked parameter set` will let you compare outputs with different parameter values.
-    - "lock" the current parameter values.
-    - Change a parameter.
-    - Run model again.
-    - Dashed lines are based on the "locked" (or older) parameter values
+
+- "lock" the current parameter values.
+- Change a parameter.
+- Run model again.
+- Dashed lines are based on the "locked" (or older) parameter values
 
 ### Vary parameter
 

--- a/inst/md/help/fit.md
+++ b/inst/md/help/fit.md
@@ -18,10 +18,11 @@ Choose/tick the parameters that are allowed to vary in the model fitting process
 ### Locked parameter set
 
 `Locked parameter set` will let you compare outputs with different parameter values.
-    - "lock" the current parameter values.
-    - Change a parameter.
-    - Run model again.
-    - Dashed lines are based on the "locked" (or older) parameter values
+
+- "lock" the current parameter values.
+- Change a parameter.
+- Run model again.
+- Dashed lines are based on the "locked" (or older) parameter values
 
 
 ### Code

--- a/inst/md/help/link.md
+++ b/inst/md/help/link.md
@@ -21,4 +21,4 @@ E.g in your model you might have a variable `date_onset` which you want to link 
 Once linked, you should see a green tick and the configurations you have selected.
 
 Note that the interface will *not* know if you have correctly linked the right variables to the right data!
-E.g. check that you have not linked `date_onset` in your model to `date_of_symptom_onset` in your dataset.
+E.g. check that you have not linked `date_report` in your model to `date_of_symptom_onset` in your dataset.

--- a/inst/md/help/state.md
+++ b/inst/md/help/state.md
@@ -4,7 +4,7 @@
 
 *Remember to save your work regularly.*
 The server will disconnect you if you are inactive for too long.
-Pressing the back button on your browser will also cause you to lost your work.
+Pressing the back button on your browser will also cause you to lose your work.
 
 ### Load
 

--- a/inst/md/help/vis.md
+++ b/inst/md/help/vis.md
@@ -12,10 +12,11 @@ If nothing is visualised, remember to specify an `End time` under `Run options`.
 ### Locked parameter set
 
 `Locked parameter set` will let you compare outputs with different parameter values.
-    - "lock" the current parameter values.
-    - Change a parameter.
-    - Run model again.
-    - Dashed lines are based on the "locked" (or older) parameter values
+
+- "lock" the current parameter values.
+- Change a parameter.
+- Run model again.
+- Dashed lines are based on the "locked" (or older) parameter values
 
 ### Code
 


### PR DESCRIPTION
Fixed typos and formatting issues in the bulleted lists in the help files.
Can never the rules for the bulleted lists and indents, but when rendered locally it now looks ok.