### PR TITLE
Support flexible time resolution of output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: odin.ui
-Version: 0.3.0
+Version: 0.3.1
 Title: Shiny User Interface for 'odin'
 Description: A user interface for 'odin', using Shiny.
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: odin.ui
-Version: 0.3.1
+Version: 0.3.2
 Title: Shiny User Interface for 'odin'
 Description: A user interface for 'odin', using Shiny.
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),

--- a/R/fit.R
+++ b/R/fit.R
@@ -82,7 +82,7 @@ odin_fit_model <- function(data_t, data_y, model, name_model_y, user, vary,
 odin_fit_objective <- function(data_t, data_y, model, name_model_y,
                                user, vary, compare) {
   compare <- match.fun(compare)
-  mod <- model(user = as.list(user))
+  mod <- model(user = as.list(user), use_dde = TRUE)
   t_after_zero <- data_t[[1]] > 0
 
   if (t_after_zero) {

--- a/R/module-control-run.R
+++ b/R/module-control-run.R
@@ -128,6 +128,7 @@ control_run_result <- function(options, values) {
       values$no_show <- replicates > options$control$max_replicates_show
     }
   }
+  values$nout <- 501
   list(options = options$options,
        control = options$control,
        values = values)

--- a/R/module-control-run.R
+++ b/R/module-control-run.R
@@ -63,23 +63,10 @@ control_run_configuration <- function(render, options) {
 
   inputs <- drop_null(list(
     control_end_time = if (options$options$control_end_time) "end",
+    control_nout = "nout",
     use_relicates = if (options$options$replicates) "replicates"))
-  if (length(inputs) == 0L) {
-    return(NULL)
-  }
 
   list(options = options, inputs = inputs)
-}
-
-
-control_run_control <- function(default_end_time = NA,
-                                default_replicates = 10,
-                                max_replicates_show = 20,
-                                max_replicates_run = 1000) {
-  list(default_end_time = default_end_time,
-       default_replicates = default_replicates,
-       max_replicates_show = max_replicates_show,
-       max_replicates_run = max_replicates_run)
 }
 
 
@@ -95,6 +82,8 @@ control_run_ui <- function(configuration, ns) {
     value_end <- options$control$default_end_time
     end <- simple_numeric_input("End time", ns("end"), value_end)
   }
+  nout <- simple_numeric_input("Number of output points", ns("nout"),
+                               options$control$default_nout)
   if (options$options$replicates) {
     value_replicates <- options$control$default_replicates
     replicates <- simple_numeric_input(
@@ -103,7 +92,7 @@ control_run_ui <- function(configuration, ns) {
 
   status <- shiny::uiOutput(ns("status"))
 
-  tags <- drop_null(list(end, replicates, status))
+  tags <- drop_null(list(end, nout, replicates, status))
   odin_control_section("Run options", tags, ns = ns)
 }
 
@@ -128,7 +117,6 @@ control_run_result <- function(options, values) {
       values$no_show <- replicates > options$control$max_replicates_show
     }
   }
-  values$nout <- 501
   list(options = options$options,
        control = options$control,
        values = values)
@@ -139,6 +127,7 @@ control_run_options <- function(control_end_time = FALSE,
                                 replicates = FALSE,
                                 scale_time = FALSE,
                                 default_end_time = NA,
+                                default_nout = 500,
                                 default_replicates = NA,
                                 max_replicates_show = 20,
                                 max_replicates_run = 1000) {
@@ -146,6 +135,7 @@ control_run_options <- function(control_end_time = FALSE,
                              replicates = replicates,
                              scale_time = scale_time),
               control = list(default_end_time = default_end_time,
+                             default_nout = default_nout,
                              default_replicates = default_replicates,
                              max_replicates_show = max_replicates_show,
                              max_replicates_run = max_replicates_run))

--- a/R/module-fit.R
+++ b/R/module-fit.R
@@ -12,6 +12,7 @@ mod_fit_ui <- function(id) {
         controls = shiny::tagList(
           shiny::uiOutput(ns("control_target")),
           mod_parameters_ui(ns("parameters")),
+          mod_control_run_ui(ns("control_run")),
           mod_lock_ui(ns("lock"))),
         status = shiny::tagList(
           shiny::uiOutput(ns("status_data")),
@@ -42,6 +43,9 @@ mod_fit_server <- function(input, output, session, data, model, link) {
   control_graph <- shiny::callModule(
     mod_control_graph_server, "control_graph",
     shiny::reactive(rv$configuration))
+  control_run <- shiny::callModule(
+    mod_control_run_server, "control_run",
+    reactive_successful(model), NULL)
   code <- shiny::callModule(
     mod_model_code_server, "code", model)
   help <- shiny::callModule(
@@ -62,6 +66,7 @@ mod_fit_server <- function(input, output, session, data, model, link) {
 
   modules <- submodules(parameters = parameters,
                         control_graph = control_graph,
+                        control_run = control_run,
                         locked = locked, download = download)
 
   output$status_data <- shiny::renderUI({
@@ -126,7 +131,7 @@ mod_fit_server <- function(input, output, session, data, model, link) {
 
   shiny::observe({
     rv$result <- with_success(vis_run(
-      rv$configuration, parameters$result(), control_run_default()))
+      rv$configuration, parameters$result(), control_run$result()))
   })
 
   shiny::observe({

--- a/R/module-fit.R
+++ b/R/module-fit.R
@@ -122,7 +122,7 @@ mod_fit_server <- function(input, output, session, data, model, link) {
       rv$fit <- NULL
       modules$reset()
       output$control_target <- shiny::renderUI(
-        fit_target_ui(rv$configuration$link, session$ns))
+        fit_target_ui(rv$configuration$link, NULL, session$ns))
     })
 
   shiny::observe({

--- a/R/module-visualise.R
+++ b/R/module-visualise.R
@@ -234,7 +234,14 @@ vis_run_single <- function(configuration, user, run_options) {
   if (model$info$features$discrete) {
     stop("Discrete time models are not supported")
   }
-  t_smooth <- seq(t_start, t_end, length.out = run_options$values$nout)
+  nout <- run_options$values$nout
+  if (nout < 1) {
+    stop("At least one output point is required")
+  }
+  ## NOTE: The +1 here is so that this is interpreted as the number of
+  ## *steps* not number of points, as we get nicer intervals generally
+  ## this way.
+  t_smooth <- seq(t_start, t_end, length.out = nout + 1)
   result_smooth <- mod$run(c(if (t_smooth[[1]] > 0) 0, t_smooth))
   i <- setdiff(colnames(result_smooth), vars$name[!vars$include])
   result_smooth <- result_smooth[, i, drop = FALSE]

--- a/R/module-visualise.R
+++ b/R/module-visualise.R
@@ -226,9 +226,10 @@ vis_run_single <- function(configuration, user, run_options) {
 
   model <- configuration$model
   if (model$info$features$has_user) {
-    mod <- model$model(user = user, unused_user_action = "ignore")
+    mod <- model$model(user = user, unused_user_action = "ignore",
+                       use_dde = TRUE)
   } else {
-    mod <- model$model()
+    mod <- model$model(use_dde = TRUE)
   }
 
   if (model$info$features$discrete) {

--- a/R/module-visualise.R
+++ b/R/module-visualise.R
@@ -300,7 +300,10 @@ vis_run_replicate <- function(configuration, user, run_options) {
   }
 
   dt <- if (run_options$options$scale_time) mod$contents()$dt else 1
-  nsteps <- 500
+  nsteps <- run_options$values$nout
+  if (nsteps < 1) {
+    stop("At least one output point is required")
+  }
   steps <- discrete_times(t_end, nsteps, dt)
   t <- steps * dt
 

--- a/R/module-visualise.R
+++ b/R/module-visualise.R
@@ -234,7 +234,7 @@ vis_run_single <- function(configuration, user, run_options) {
   if (model$info$features$discrete) {
     stop("Discrete time models are not supported")
   }
-  t_smooth <- seq(t_start, t_end, length.out = 501)
+  t_smooth <- seq(t_start, t_end, length.out = run_options$values$nout)
   result_smooth <- mod$run(c(if (t_smooth[[1]] > 0) 0, t_smooth))
   i <- setdiff(colnames(result_smooth), vars$name[!vars$include])
   result_smooth <- result_smooth[, i, drop = FALSE]

--- a/R/plotly.R
+++ b/R/plotly.R
@@ -165,7 +165,8 @@ plotly_with_redraw <- function(series, previous, ...) {
     action <- "redraw"
     data <- list(x = unname(lapply(series, "[[", "x")),
                  y = unname(lapply(series, "[[", "y")),
-                 yaxis = unname(lapply(series, "[[", "yaxis")))
+                 yaxis = unname(lapply(series, "[[", "yaxis")),
+                 name = unname(lapply(series, "[[", "name")))
   } else {
     action <- "draw"
     data <- plot_plotly(series, ...)

--- a/inst/md/help/vis.md
+++ b/inst/md/help/vis.md
@@ -37,3 +37,7 @@ Underneath the plot window there is a `Download` option.
 
 1. Modelled: downloads the modelled outputs e.g. the value of S, I, R over time.
 2. Parameters: downloads your current parameter values.
+
+## Run options
+
+You can control the resolution at which the data is plotted (and downloadable) by changing the number of output points. This does not affect how the equations are solved, just the output. Be aware that very large numbers will result in large downloads and somewhat slower plotting.

--- a/tests/testthat/test-module-visualise.R
+++ b/tests/testthat/test-module-visualise.R
@@ -18,6 +18,7 @@ test_that("run model, with missing zero time", {
   link <- link_result(list("x", "y"), c("a", "c"))
   configuration <- common_model_data_configuration(model, data, link)
   run_options <- control_run_options_validate(NULL)
+  run_options$values <- list(nout = 500)
 
   user <- list(a = 2, b = 1)
   res <- vis_run(configuration, user = user, run_options = run_options)
@@ -76,6 +77,7 @@ test_that("plot", {
   link <- link_result(list("x", "y"), c("a", "c"))
   configuration <- common_model_data_configuration(model, data, link)
   run_options <- control_run_options_validate(NULL)
+  run_options$values <- list(nout = 500)
   user <- list(a = 2, b = 1)
   res <- vis_run(configuration, user = user, run_options = run_options)
   y2 <- list(x = FALSE, y = TRUE)
@@ -125,6 +127,7 @@ test_that("locked series", {
   link <- link_result(list("x", "y"), c("a", "c"))
   configuration <- common_model_data_configuration(model, data, link)
   run_options <- control_run_options_validate(NULL)
+  run_options$values <- list(nout = 500)
   user1 <- list(a = 2, b = 1)
   user2 <- list(a = 1, b = 1)
   res1 <- vis_run(configuration, user = user1, run_options = run_options)


### PR DESCRIPTION
This PR will allow control over the plotting and download resolution of data

It is currently live for testing on the staging server, for example

* https://shiny.dide.imperial.ac.uk:9000/staging/infectiousdiseasemodels-2019/introduction/
* https://shiny.dide.imperial.ac.uk:9000/staging/infectiousdiseasemodels-2019/ebola/
* https://shiny.dide.imperial.ac.uk:9000/staging/infectiousdiseasemodels-2019/stochasticity/example3/

Please verify this works as expected.  It is probable that practical leaders need to be told, and some screenshots might need updating